### PR TITLE
Disable Vale.Spelling; enforce house style only

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -10,6 +10,14 @@ Vocab = PaperMoon
 [*.md]
 BasedOnStyles = Vale, PaperMoon
 
+# Vale.Spelling (Hunspell) is disabled: this styleguide enforces house style,
+# not spelling. On technical docs the spell-checker flags an endless tail of
+# valid tool/package names (npm, toolchain, Turbopack, ...) with no
+# typo-catching benefit worth the vocab-curation toil. The curated PaperMoon
+# house-style rules and Vale.Repetition/Vale.Terms stay enabled. Adopting
+# repos inherit this as the default house behavior.
+Vale.Spelling = NO
+
 TokenIgnores = (?:dApp|TestNet|MainNet|ERC-\d+|JSON-RPC)
 BlockIgnores = (?s) *(```.*?```)
 


### PR DESCRIPTION
## Summary

Disable `Vale.Spelling` in the canonical `.vale.ini` so the styleguide enforces **house style**, not spelling.

```ini
Vale.Spelling = NO
```

## Why

`Vale.Spelling` (Hunspell) arrived for free with the base `Vale` style. On technical documentation it flags an endless tail of valid tool and package names — `npm`, `dev`, `toolchain`, `Turbopack`, etc. — as misspellings, with no meaningful typo-catching benefit to offset the ongoing vocab-curation toil.

This came up downstream in [polkadot-developers/polkadot-docs#1678](https://github.com/polkadot-developers/polkadot-docs/pull/1678): a reviewer started a thread collecting words Vale was flagging locally (`dev`, `devtools`, `npm`, `toolchain`, `Turbopack`, `PWallet`) — all valid terms, all `Vale.Spelling` false positives. We disabled it there; this proposes making it the canonical default so every adopting repo inherits the right behavior instead of rediscovering the noise and overriding locally.

The curated PaperMoon house-style rules plus `Vale.Repetition` and `Vale.Terms` stay enabled — those are the point of the styleguide.

## Tradeoff

Genuine prose typos are no longer caught by Vale and rely on review. On a heavily technical corpus that's a worthwhile trade given the false-positive rate.

## Note on propagation

`.vale.ini` is not synced by adopters (the sync script copies only `styles/PaperMoon/*.yml` and the PaperMoon vocab). So this doesn't auto-propagate — it sets a better default for new repos copying this config as their template, and aligns the styleguide repo's own linting with that default.
